### PR TITLE
feat: add prompt builder with citations

### DIFF
--- a/backend/src/orchestrator/qa_orchestrator.py
+++ b/backend/src/orchestrator/qa_orchestrator.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 """QA orchestrator combining retrieval and LLM."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from sqlalchemy.orm import Session
 
-from src.prompts.answer_with_citations import build_user_prompt
-from src.prompts.system import SYSTEM_PROMPT
+from src.prompts.answer_with_citations import build_prompt, postprocess_answer
 from src.retriever.hybrid_retriever import hybrid_search
 from src.services.llm.factory import get_llm
 
@@ -15,15 +14,17 @@ def answer(db: Session, query: str, max_ctx_chars: int = 12000) -> Dict[str, Any
     """Answer query using hybrid retrieval and LLM."""
 
     candidates = hybrid_search(db, query, topk=12)
-    ctx = []
+    ctx: List[Dict[str, Any]] = []
     total = 0
     for c in candidates:
-        t = c.get("text") or ""
+        t = c.get("pasal_text") or c.get("display_text") or c.get("text") or ""
         if total + len(t) > max_ctx_chars:
             break
-        ctx.append({"citation": c["citation"], "text": t})
+        ctx.append(c)
         total += len(t)
     llm = get_llm()
-    up = build_user_prompt(query, ctx)
-    out = llm.complete(SYSTEM_PROMPT, up, stream=False)
-    return {"answer": out.get("text", ""), "candidates": candidates[: len(ctx)]}
+    system_prompt, user_prompt = build_prompt(query, ctx)
+    out = llm.complete(system_prompt, user_prompt, stream=False)
+    citations = [cand.get("citation_string") or cand.get("citation", "") for cand in ctx]
+    ans = postprocess_answer(out.get("text", ""), citations)
+    return {"answer": ans, "candidates": ctx}

--- a/backend/src/prompts/answer_with_citations.py
+++ b/backend/src/prompts/answer_with_citations.py
@@ -1,14 +1,51 @@
 from __future__ import annotations
-"""Build user prompt with context citations."""
+"""Prompt builder ensuring citations in answers."""
 
-from typing import Dict, List
+from typing import Any, Dict, Iterable, List, Tuple
 
 
-def build_user_prompt(query: str, contexts: List[Dict[str, str]]) -> str:
-    """Compose prompt with numbered citations."""
+def build_prompt(user_query: str, candidates: List[Dict[str, Any]]) -> Tuple[str, str]:
+    """Return system and user prompts for answering with citations.
 
-    blocks = []
-    for i, c in enumerate(contexts, 1):
-        blocks.append(f"[{i}] {c['citation']}\n{c['text']}\n")
-    ctx = "\n".join(blocks)
-    return f"Pertanyaan: {query}\n\nKonteks:\n{ctx}\nJawab dengan menyertakan [citation]."
+    Each candidate may contain keys:
+        * citation_string or citation
+        * display_text: text for leaf units
+        * pasal_text: full article text for top candidate
+        * text: fallback content
+    The first candidate is treated as the top article; subsequent ones as leaf
+    units. """
+
+    system_prompt = (
+        "Anda asisten hukum. Jangan mengarang nomor pasal dan hanya gunakan "
+        "citation_string yang diberikan ketika menyebut sumber."  # noqa: E501
+    )
+
+    blocks: List[str] = []
+    for idx, cand in enumerate(candidates, 1):
+        citation = cand.get("citation_string") or cand.get("citation") or ""
+        if idx == 1 and cand.get("pasal_text"):
+            text = cand["pasal_text"]
+        else:
+            text = cand.get("display_text") or cand.get("text") or ""
+        blocks.append(f"[{idx}] {citation}\n{text}")
+    context = "\n\n".join(blocks)
+
+    user_prompt = (
+        f"Pertanyaan: {user_query}\n\n"  # noqa: E501
+        f"Konteks:\n{context}\n\n"
+        "Jawab dalam poin-poin singkat. Akhiri dengan blok 'Sumber:' yang "
+        "berisi daftar citation_string sesuai nomor."  # noqa: E501
+    )
+    return system_prompt, user_prompt
+
+
+def postprocess_answer(answer: str, citations: Iterable[str]) -> str:
+    """Ensure answer contains a 'Sumber' block.
+
+    If missing, append the citations provided.
+    """
+
+    if "Sumber:" not in answer:
+        src = "\n".join(f"- {c}" for c in citations)
+        answer = answer.rstrip() + f"\n\nSumber:\n{src}"
+    return answer


### PR DESCRIPTION
## Summary
- build prompts that enforce citation use and provide full pasal context
- ensure answers include a `Sumber` block
- update QA orchestrator to use new prompt and postprocessor

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896fcfce93c8329b9ab49462863f0f1