### PR TITLE
Refactor ingestion pipeline and introduce retryable PDF downloads

### DIFF
--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -1,121 +1,117 @@
 #!/usr/bin/env python3
-"""
-Simple Document Ingestion - Direct orchestrator calls, no pipeline abstractions
-"""
+"""Simple Document Ingestion - Direct orchestrator calls, no pipeline abstractions"""
 
 import argparse
 import asyncio
-import sys
 import json
-from datetime import datetime
+import logging
+import sys
 from pathlib import Path
+from typing import Any, Dict, List
 
 from src.services.crawler.crawler_orchestrator import CrawlerOrchestrator
 from src.services.pdf import PDFOrchestrator
 from src.config.crawler_config import CrawlerConfig
 
+logger = logging.getLogger(__name__)
 
-async def main():
-    """Simple ingestion using direct orchestrator calls"""
-    parser = argparse.ArgumentParser(description='Simple Document Ingestion')
-    parser.add_argument('--query', default='', help='Search query')
-    parser.add_argument('--type', default='', help='Type of regulation')
-    parser.add_argument('--year', default='', help='Year of regulation')
-    parser.add_argument('--limit', type=int, default=10, help='Maximum number of documents')
-    parser.add_argument('--output-dir', default='./data/json', help='Output directory for JSON files')
-    parser.add_argument('--pdf-dir', default='./data/pdfs', help='Output directory for PDF files')
-    parser.add_argument('--no-pdf', action='store_true', help='Skip PDF processing')
-    # python -m src.ingestion --txt-dir "data/text" --process-txt-batch
-    parser.add_argument('--txt-dir', help='Directory containing TXT files for batch processing')
-    parser.add_argument('--process-txt-batch', action='store_true', help='Process all TXT files in txt-dir that match existing JSON metadata')
-    parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose logging')
 
-    args = parser.parse_args()
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for ingestion."""
+    parser = argparse.ArgumentParser(description="Simple Document Ingestion")
+    parser.add_argument("--query", default="", help="Search query")
+    parser.add_argument("--type", default="", help="Type of regulation")
+    parser.add_argument("--year", default="", help="Year of regulation")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum number of documents")
+    parser.add_argument("--output-dir", default="./data/json", help="Output directory for JSON files")
+    parser.add_argument("--pdf-dir", default="./data/pdfs", help="Output directory for PDF files")
+    parser.add_argument("--no-pdf", action="store_true", help="Skip PDF processing")
+    parser.add_argument("--txt-dir", help="Directory containing TXT files for batch processing")
+    parser.add_argument(
+        "--process-txt-batch",
+        action="store_true",
+        help="Process all TXT files in txt-dir that match existing JSON metadata",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    return parser.parse_args()
 
-    # Setup logging
+
+async def process_pdf_documents(
+    crawler: CrawlerOrchestrator, pdf_processor: PDFOrchestrator, documents: List[Dict[str, Any]]
+) -> int:
+    """Process documents with available PDFs concurrently."""
+
+    async def _process(doc: Dict[str, Any]) -> None:
+        nonlocal processed_count
+        if not doc.get("pdf_path"):
+            return
+        enhanced = await asyncio.to_thread(pdf_processor.process_document_complete, doc)
+        if enhanced.get("doc_content"):
+            await crawler.save_regulation_json(enhanced, update_existing=True)
+            crawler.save_text_file(enhanced)
+            doc.update(enhanced)
+            processed_count += 1
+
+    processed_count = 0
+    await asyncio.gather(*(_process(d) for d in documents))
+    return processed_count
+
+
+async def run_ingestion(args: argparse.Namespace) -> None:
+    """Execute the ingestion pipeline based on parsed arguments."""
     config = CrawlerConfig()
-    if args.verbose:
-        config.setup_logging("DEBUG")
-    else:
-        config.setup_logging("INFO")
+    config.setup_logging("DEBUG" if args.verbose else "INFO")
 
     try:
-        # Check if batch TXT processing is requested
         if args.process_txt_batch and args.txt_dir:
-            processed_count = await process_txt_batch(args.txt_dir, args.output_dir, args.pdf_dir)
-            print(f"\n{'='*60}")
-            print(f"BATCH TXT PROCESSING RESULTS")
-            print(f"{'='*60}")
-            print(f"TXT files processed: {processed_count}")
-            print(f"{'='*60}")
+            processed = await process_txt_batch(args.txt_dir, args.output_dir, args.pdf_dir)
+            logger.info("BATCH TXT PROCESSING RESULTS")
+            logger.info("TXT files processed: %d", processed)
             return
-        # Step 1: Crawl documents
+
         crawler = CrawlerOrchestrator(output_dir=args.output_dir, pdf_dir=args.pdf_dir)
         documents = await crawler.crawl_regulations(
-            query=args.query,
-            regulation_type=args.type,
-            year=args.year,
-            limit=args.limit
+            query=args.query, regulation_type=args.type, year=args.year, limit=args.limit
         )
 
-        print(f"\n{'='*60}")
-        print(f"INGESTION RESULTS")
-        print(f"{'='*60}")
-        print(f"Documents crawled: {len(documents)}")
+        logger.info("INGESTION RESULTS")
+        logger.info("Documents crawled: %d", len(documents))
 
-        # Step 2: Process PDFs if enabled
         pdfs_processed = 0
         if not args.no_pdf:
             pdf_processor = PDFOrchestrator()
+            pdfs_processed = await process_pdf_documents(crawler, pdf_processor, documents)
 
-            for doc in documents:
-                if doc.get('pdf_path'):
-                    enhanced_doc = pdf_processor.process_document_complete(doc)
-                    if enhanced_doc.get('doc_content'):
-                        # Update files
-                        await crawler.save_regulation_json(enhanced_doc, update_existing=True)
-                        crawler.save_text_file(enhanced_doc)
-                        pdfs_processed += 1
-                        doc.update(enhanced_doc)
+        logger.info("PDFs processed: %d", pdfs_processed)
+        logger.info("Processing: %s", "Enabled" if not args.no_pdf else "Disabled")
 
-        print(f"PDFs processed: {pdfs_processed}")
-        print(f"Processing: {'Enabled' if not args.no_pdf else 'Disabled'}")
-        print(f"{'='*60}")
-
-        # Show sample documents
         if documents:
-            print(f"\nProcessed documents:")
             for i, doc in enumerate(documents[:3], 1):
-                title = doc.get('doc_title', doc.get('title', 'Unknown'))
-                has_content = 'Yes' if doc.get('doc_content', doc.get('content')) else 'No'
-                print(f"{i}. {title} (Content: {has_content})")
-
+                title = doc.get("doc_title", doc.get("title", "Unknown"))
+                has_content = "Yes" if doc.get("doc_content", doc.get("content")) else "No"
+                logger.info("%d. %s (Content: %s)", i, title, has_content)
             if len(documents) > 3:
-                print(f"... and {len(documents) - 3} more documents")
+                logger.info("... and %d more documents", len(documents) - 3)
 
-        # File summary
         json_files = len(list(Path(args.output_dir).glob("*.json"))) if Path(args.output_dir).exists() else 0
         pdf_files = len(list(Path(args.pdf_dir).glob("*.pdf"))) if Path(args.pdf_dir).exists() else 0
-        print(f"\nFiles: {json_files} JSON, {pdf_files} PDF")
-        print(f"{'='*60}")
-
+        logger.info("Files: %d JSON, %d PDF", json_files, pdf_files)
     except KeyboardInterrupt:
-        print("Ingestion interrupted by user")
-    except Exception as e:
-        print(f"Ingestion failed: {str(e)}")
+        logger.warning("Ingestion interrupted by user")
+    except Exception:
+        logger.exception("Ingestion failed")
         sys.exit(1)
 
 
 async def process_txt_batch(txt_dir: str, json_dir: str, pdf_dir: str) -> int:
-    """Batch process TXT files berdasarkan filename matching"""
+    """Batch process TXT files based on filename matching."""
     txt_path = Path(txt_dir)
     json_path = Path(json_dir)
 
     if not txt_path.exists():
-        print(f"TXT directory not found: {txt_dir}")
+        logger.warning("TXT directory not found: %s", txt_dir)
         return 0
 
-    # Get all TXT files
     txt_files = list(txt_path.glob("*.txt"))
     processed_count = 0
 
@@ -123,42 +119,44 @@ async def process_txt_batch(txt_dir: str, json_dir: str, pdf_dir: str) -> int:
 
     for txt_file in txt_files:
         try:
-            # Extract base filename (without extension)
-            base_name = txt_file.stem  # undang_undang_1_2025
-
-            # Look for matching JSON file
+            base_name = txt_file.stem
             json_file = json_path / f"{base_name}.json"
 
             if not json_file.exists():
-                print(f"⚠️  No matching JSON found for: {txt_file.name}")
+                logger.warning("No matching JSON found for: %s", txt_file.name)
                 continue
 
-            # Load existing JSON metadata
-            with open(json_file, 'r', encoding='utf-8') as f:
-                regulation_data = json.load(f)
+            try:
+                with open(json_file, "r", encoding="utf-8") as f:
+                    regulation_data = json.load(f)
+            except json.JSONDecodeError:
+                logger.error("Invalid JSON in %s", json_file)
+                continue
 
-            # Read TXT content
-            with open(txt_file, 'r', encoding='utf-8') as f:
+            with open(txt_file, "r", encoding="utf-8") as f:
                 txt_content = f.read()
 
-            print(f"🔄 Processing: {txt_file.name}")
+            logger.info("Processing: %s", txt_file.name)
 
-            # Process TXT content (build tree, etc)
             enhanced_doc = pdf_processor.process_txt_content(regulation_data, txt_content)
 
-            # Save updated JSON
             from src.services.crawler.crawler_orchestrator import DateTimeEncoder
-            with open(json_file, 'w', encoding='utf-8') as f:
+            with open(json_file, "w", encoding="utf-8") as f:
                 json.dump(enhanced_doc, f, ensure_ascii=False, indent=2, cls=DateTimeEncoder)
 
-            print(f"✅ Successfully processed: {txt_file.name}")
+            logger.info("Successfully processed: %s", txt_file.name)
             processed_count += 1
-
-        except Exception as e:
-            print(f"❌ Error processing {txt_file.name}: {str(e)}")
+        except Exception:
+            logger.exception("Error processing %s", txt_file.name)
             continue
 
     return processed_count
+
+
+async def main() -> None:
+    """Entry point for command line execution."""
+    args = parse_args()
+    await run_ingestion(args)
 
 
 if __name__ == "__main__":

--- a/src/services/crawler/file_downloader.py
+++ b/src/services/crawler/file_downloader.py
@@ -8,155 +8,154 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import aiohttp
 
 from src.config.crawler_config import CrawlerConfig
+from .utils import retry_async
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileDownloader:
-    """Handle PDF downloading and file management with retry mechanism"""
+    """Handle PDF downloading and file management with retry mechanism."""
 
-    def __init__(self):
-        """Initialize with centralized configuration"""
+    def __init__(self) -> None:
+        """Initialize with centralized configuration."""
         self.config = CrawlerConfig
 
-    async def download_pdf(self, pdf_url: str, pdf_dir: str, filename: str, session: Optional[aiohttp.ClientSession] = None) -> Optional[str]:
-        """Download PDF file with duplicate checking and retry mechanism"""
+    async def download_pdf(
+        self,
+        pdf_url: str,
+        pdf_dir: str,
+        filename: str,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> Optional[str]:
+        """Download PDF file with duplicate checking and retry mechanism."""
         try:
             os.makedirs(pdf_dir, exist_ok=True)
-
             file_path = os.path.join(pdf_dir, filename)
 
             if os.path.exists(file_path):
-                logging.info(f"BPK PDF file already exists, skipping download: {file_path}")
+                logger.info("BPK PDF file already exists, skipping download: %s", file_path)
                 return file_path
 
-            retry_config = self.config.get_retry_config()
-            download_config = self.config.get_download_config()
-            max_retries = retry_config['download_retries']
-            retry_delay = retry_config['download_delay']
+            retry_cfg = self.config.get_retry_config()
+            download_cfg = self.config.get_download_config()
 
             session_to_use = session
-            close_session_after = False
-
+            close_session = False
             if not session_to_use or session_to_use.closed:
-                connection_config = self.config.get_connection_config()
-                download_timeout_config = self.config.get_download_timeout_config()
-
-                connector = aiohttp.TCPConnector(**connection_config)
+                conn_cfg = self.config.get_connection_config()
+                timeout_cfg = self.config.get_download_timeout_config()
+                connector = aiohttp.TCPConnector(**conn_cfg)
                 session_to_use = aiohttp.ClientSession(
                     headers=self.config.get_http_headers(),
-                    timeout=aiohttp.ClientTimeout(**download_timeout_config),
-                    connector=connector
+                    timeout=aiohttp.ClientTimeout(**timeout_cfg),
+                    connector=connector,
                 )
-                close_session_after = True
+                close_session = True
+
+            async def _attempt() -> str:
+                logger.info("Downloading BPK PDF: %s", pdf_url)
+                await asyncio.sleep(download_cfg["sleep_between_requests"])
+                pdf_headers = self.config.get_pdf_headers(self.config.get_base_url())
+                async with session_to_use.get(pdf_url, headers=pdf_headers) as response:
+                    if response.status != 200:
+                        raise RuntimeError(f"HTTP {response.status}")
+                    content_length = response.headers.get("Content-Length")
+                    total_size = int(content_length) if content_length else 0
+                    if total_size:
+                        logger.info("PDF size: %.1f MB", total_size / (1024 * 1024))
+
+                    downloaded_size = 0
+                    chunk_size = download_cfg["chunk_size"]
+                    pdf_chunks: List[bytes] = []
+                    async for chunk in response.content.iter_chunked(chunk_size):
+                        pdf_chunks.append(chunk)
+                        downloaded_size += len(chunk)
+
+                    if total_size:
+                        logger.info(
+                            "Downloaded %.1f MB / %.1f MB",
+                            downloaded_size / (1024 * 1024),
+                            total_size / (1024 * 1024),
+                        )
+                    else:
+                        logger.info("Downloaded %.1f MB", downloaded_size / (1024 * 1024))
+
+                    content = b"".join(pdf_chunks)
+                    if not content.startswith(b"%PDF"):
+                        raise RuntimeError("Not a valid PDF")
+
+                    with open(file_path, "wb") as f:
+                        f.write(content)
+                    file_size = len(content) / (1024 * 1024)
+                    logger.info(
+                        "Downloaded BPK PDF successfully: %s (%.1f MB)",
+                        file_path,
+                        file_size,
+                    )
+                    return file_path
 
             try:
-                for attempt in range(max_retries):
-                    try:
-                        if attempt > 0:
-                            await asyncio.sleep(retry_delay * attempt)
-                            logging.info(f"Retrying BPK PDF download attempt {attempt + 1}/{max_retries}")
-
-                        logging.info(f"Downloading BPK PDF: {pdf_url}")
-
-                        await asyncio.sleep(download_config['sleep_between_requests'])
-
-                        pdf_headers = self.config.get_pdf_headers(self.config.get_base_url())
-
-                        async with session_to_use.get(pdf_url, headers=pdf_headers) as response:
-                            if response.status == 200:
-                                # Get content length for progress tracking
-                                content_length = response.headers.get('Content-Length')
-                                if content_length:
-                                    total_size = int(content_length)
-                                    logging.info(f"PDF size: {total_size / (1024*1024):.1f} MB")
-                                else:
-                                    total_size = 0
-
-                                # Optimized streaming download
-                                downloaded_size = 0
-                                chunk_size = download_config['chunk_size']
-                                pdf_chunks = []
-
-                                try:
-                                    async for chunk in response.content.iter_chunked(chunk_size):
-                                        pdf_chunks.append(chunk)
-                                        downloaded_size += len(chunk)
-
-                                    # Single progress log at completion
-                                    if total_size > 0:
-                                        logging.info(f"Downloaded {downloaded_size / (1024*1024):.1f} MB / {total_size / (1024*1024):.1f} MB")
-                                    else:
-                                        logging.info(f"Downloaded {downloaded_size / (1024*1024):.1f} MB")
-
-                                except Exception as chunk_error:
-                                    logging.error(f"Error during streaming download: {chunk_error}")
-                                    raise
-
-                                # Combine chunks
-                                content = b''.join(pdf_chunks)
-
-                                if content.startswith(b'%PDF'):
-                                    with open(file_path, 'wb') as f:
-                                        f.write(content)
-
-                                    file_size = len(content) / (1024 * 1024)  # MB
-                                    logging.info(f"Downloaded BPK PDF successfully: {file_path} ({file_size:.1f} MB)")
-                                    return file_path
-                                else:
-                                    logging.error(f"Downloaded content is not a valid PDF: {pdf_url}")
-                                    return None
-                            else:
-                                logging.error(f"Failed to download BPK PDF: HTTP {response.status}")
-                                if attempt == max_retries - 1:
-                                    return None
-                                continue
-
-                    except Exception as e:
-                        logging.error(f"Error downloading BPK PDF (attempt {attempt + 1}): {str(e)}")
-                        if attempt == max_retries - 1:
-                            return None
-                        continue
-
+                return await retry_async(
+                    _attempt,
+                    retries=retry_cfg["download_retries"],
+                    delay=retry_cfg["download_delay"],
+                    logger=logger,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error("Error downloading BPK PDF: %s", exc)
                 return None
-
             finally:
-                if close_session_after and session_to_use:
+                if close_session and session_to_use:
                     await session_to_use.close()
 
-        except Exception as e:
-            logging.error(f"Error in BPK PDF download: {str(e)}")
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error in BPK PDF download: %s", exc)
             return None
 
-    async def download_pdf_simple(self, pdf_url: str, regulation: dict, pdf_dir: Path) -> Optional[Path]:
-        """Download PDF file from URL - simplified version"""
+    async def download_pdf_simple(
+        self,
+        pdf_url: str,
+        regulation: dict,
+        pdf_dir: Path,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> Optional[Path]:
+        """Download PDF file from URL - simplified version."""
         try:
             filename = self.config.generate_pdf_filename(regulation)
             pdf_path = pdf_dir / filename
 
             if pdf_path.exists():
-                logging.info(f"PDF already exists: {pdf_path}")
+                logger.info("PDF already exists: %s", pdf_path)
                 return pdf_path
 
-            logging.info(f"Downloading PDF: {pdf_url}")
+            logger.info("Downloading PDF: %s", pdf_url)
 
-            async with aiohttp.ClientSession(headers=self.config.get_http_headers()) as session:
-                async with session.get(pdf_url) as response:
+            session_to_use = session
+            close_session = False
+            if not session_to_use or session_to_use.closed:
+                session_to_use = aiohttp.ClientSession(headers=self.config.get_http_headers())
+                close_session = True
+
+            try:
+                async with session_to_use.get(pdf_url) as response:
                     if response.status == 200:
                         content = await response.read()
-
-                        with open(pdf_path, 'wb') as f:
+                        with open(pdf_path, "wb") as f:
                             f.write(content)
-
-                        logging.info(f"PDF downloaded successfully: {pdf_path}")
+                        logger.info("PDF downloaded successfully: %s", pdf_path)
                         return pdf_path
-                    else:
-                        logging.error(f"Failed to download PDF: HTTP {response.status}")
-                        return None
+                    logger.error("Failed to download PDF: HTTP %s", response.status)
+                    return None
+            finally:
+                if close_session:
+                    await session_to_use.close()
 
-        except Exception as e:
-            logging.error(f"Error downloading PDF from {pdf_url}: {str(e)}")
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error downloading PDF from %s: %s", pdf_url, exc)
             return None

--- a/src/services/crawler/utils.py
+++ b/src/services/crawler/utils.py
@@ -1,0 +1,26 @@
+import asyncio
+import logging
+from typing import Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+async def retry_async(
+    operation: Callable[[], Awaitable[T]],
+    retries: int,
+    delay: float,
+    logger: logging.Logger,
+) -> T:
+    """Execute an async operation with simple exponential backoff."""
+    last_exc: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            return await operation()
+        except Exception as exc:  # pylint: disable=broad-except
+            last_exc = exc
+            logger.error("retry_failed", exc_info=exc)
+            if attempt < retries:
+                await asyncio.sleep(delay * attempt)
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("retry_async: no operation executed")


### PR DESCRIPTION
## Summary
- separate argument parsing from ingestion logic
- add concurrent PDF processing and structured logging
- handle TXT batch JSON errors gracefully
- centralize crawler retry/backoff logic with shared helper
- inject aiohttp sessions into file downloads for easier testing

## Testing
- `pytest -q`
- `flake8 --max-line-length=120 src/ingestion.py src/services/crawler/file_downloader.py src/services/crawler/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68973a9bd3dc832993069b9628cbbfb8