### PR TITLE
fix: ensure CLI commands work without external services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,6 @@ uvicorn[standard]==0.24.0
 
 
 
-<<<<<<< wv2927-codex/fix-issues-in-agents.md-and-todo_next.md
-- [x] **FIX**: Remove nonexistent `dv.content_type` column and use `lu.unit_type`
-- [x] **FIX**: Lazily import `JinaEmbedder` in `HybridRetriever` to avoid NameError
-=======
->>>>>>> main
 
 # Configuration Management
 pydantic==2.5.0
@@ -89,7 +84,7 @@ ruff==0.1.6
 mypy==1.7.1
 
 # Type stubs
-types-requests==2.31.0.20231114
+types-requests==2.31.0.20240402
 
 # =============================================================================
 # PRODUCTION DEPLOYMENT

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -77,6 +77,11 @@ def init_db() -> None:
     Use Alembic migrations for production.
     """
     from .models import Base
+
+    # Ensure required extensions exist (e.g., pgvector)
+    with engine.begin() as conn:
+        if engine.url.get_backend_name() == "postgresql":
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
     Base.metadata.create_all(bind=engine)
 

--- a/src/services/search/hybrid_search.py
+++ b/src/services/search/hybrid_search.py
@@ -641,6 +641,89 @@ def create_search_service(
     )
 
 
+def _get_document_outline_impl(self, doc_id: str, include_content: bool = False) -> Dict[str, Any]:
+    """Get structured outline of a legal document."""
+    start_time = time.time()
+    try:
+        logger.info(f"Getting document outline for: {doc_id}")
+        with get_db_session() as db:
+            from ...db.models import LegalDocument
+
+            doc = db.query(LegalDocument).filter_by(doc_id=doc_id).first()
+            if not doc:
+                return {"doc_id": doc_id, "outline": [], "error": "Document not found"}
+
+            units_query = text(
+                """
+                SELECT
+                    unit_id,
+                    unit_type,
+                    number_label,
+                    ordinal_int,
+                    ordinal_suffix,
+                    label_display,
+                    title,
+                    citation_string,
+                    parent_pasal_id,
+                    hierarchy_path,
+                    CASE WHEN :include_content THEN local_content ELSE NULL END as content
+                FROM legal_units
+                WHERE document_id = :doc_id
+                ORDER BY seq_sort_key, ordinal_int, ordinal_suffix
+                """
+            )
+
+            results = db.execute(
+                units_query, {"doc_id": doc.id, "include_content": include_content}
+            ).fetchall()
+
+            outline = _build_outline_tree_impl(results)
+            duration_ms = (time.time() - start_time) * 1000
+
+            response = {
+                "doc_id": doc_id,
+                "document": {
+                    "title": doc.doc_title,
+                    "form": doc.doc_form.value,
+                    "number": doc.doc_number,
+                    "year": doc.doc_year,
+                    "status": doc.doc_status.value,
+                },
+                "outline": outline,
+                "total_units": len(results),
+                "duration_ms": duration_ms,
+            }
+
+            logger.info(
+                "Document outline retrieved",
+                extra=log_timing("get_document_outline", duration_ms),
+            )
+            return response
+    except Exception as e:
+        logger.error(f"Failed to get document outline for {doc_id}: {e}")
+        return {"doc_id": doc_id, "outline": [], "error": str(e)}
+
+
+def _build_outline_tree_impl(units: List[Any]) -> List[Dict[str, Any]]:
+    """Build hierarchical outline tree from flat unit list."""
+    outline: List[Dict[str, Any]] = []
+    for unit in units:
+        item: Dict[str, Any] = {
+            "unit_id": unit.unit_id,
+            "type": unit.unit_type,
+            "label": unit.label_display or unit.title or unit.unit_id,
+            "hierarchy_path": unit.hierarchy_path,
+        }
+        if unit.content is not None:
+            item["content"] = unit.content
+        outline.append(item)
+    return outline
+
+
+HybridSearchService.get_document_outline = _get_document_outline_impl
+HybridSearchService._build_outline_tree = staticmethod(_build_outline_tree_impl)
+
+
 # Example usage and testing
 if __name__ == "__main__":
     import asyncio


### PR DESCRIPTION
## Summary
- drop merge artifacts and add valid `types-requests` stub version
- auto-create pgvector extension and allow zero-vector fallback when Jina API key missing
- harden indexing and search: tolerate bad doc forms, skip duplicate units, uppercase enum filters, and attach outline helpers

## Testing
- `python -m src.main init-db --reset --force`
- `python -m src.main index data/json`
- `python -m src.main index data/json/undang_undang_2_2025.json`
- `python -m src.main search "pasal 1 ayat 2"`
- `python -m src.main search "pertambangan" --doc-forms UU --doc-years 2009,2025`
- `python -m src.main outline UU-2025-2`
- `python -m src.main status`
- `python -m src.main benchmark --rerank`
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976394a41083299c02b6ca817efe3d